### PR TITLE
Fixes

### DIFF
--- a/camera.c
+++ b/camera.c
@@ -177,15 +177,15 @@ HSM_EVENT CAMERA_StateOnDispMenuHndlr(HSM *This, HSM_EVENT event, UINT32 param)
 
 void CAMERA_Init(CAMERA *This, char *name)
 {
-    // Step 1: Initiailize the HSM and starting state
-    HSM_Create((HSM *)This, name, &CAMERA_StateOff);
-    // Step 2: Create the HSM States
+    // Step 1: Create the HSM States
     HSM_STATE_Create(&CAMERA_StateOff, "Off", CAMERA_StateOffHndlr, NULL);
     HSM_STATE_Create(&CAMERA_StateOn, "On", CAMERA_StateOnHndlr, NULL);
     HSM_STATE_Create(&CAMERA_StateOnShoot, "On.Shoot", CAMERA_StateOnShootHndlr, &CAMERA_StateOn);
     HSM_STATE_Create(&CAMERA_StateOnDisp, "On.Disp", CAMERA_StateOnDispHndlr, &CAMERA_StateOn);
     HSM_STATE_Create(&CAMERA_StateOnDispPlay, "On.Disp.Play", CAMERA_StateOnDispPlayHndlr, &CAMERA_StateOnDisp);
     HSM_STATE_Create(&CAMERA_StateOnDispMenu, "On.Disp.Menu", CAMERA_StateOnDispMenuHndlr, &CAMERA_StateOnDisp);
+    // Step 2: Initiailize the HSM and starting state
+    HSM_Create((HSM *)This, name, &CAMERA_StateOff);
     // Step 3: [Optional] Enable HSM debug
     This->parent.hsmDebug = 1;
     // Step 4: CAMERA member initialization

--- a/hsm.c
+++ b/hsm.c
@@ -167,6 +167,6 @@ void HSM_Tran(HSM *This, HSM_STATE *nextState, UINT32 param, void (*method)(void
 #ifdef HSM_INIT_FEATURE
     // 6) Invoke INIT signal, NOTE: Only HSME_INIT can recursively call HSM_Tran()
     HSM_DEBUGC("  %s[%s](INIT)\n", This->name, nextState->name);
-    This->curState->handler(This, HSME_INIT, 0);
+    This->curState->handler(This, HSME_INIT, param);
 #endif // HSM_INIT_FEATURE
 }

--- a/hsm.c
+++ b/hsm.c
@@ -24,18 +24,9 @@ SOFTWARE.
 
 #include "hsm.h"
 
-#ifdef HSM_DEBUG
-#include <stdio.h>
-#define DEBUGC(...) { if(This->hsmDebug) printf(__VA_ARGS__); }
-#define DEBUG(...)  printf(__VA_ARGS__)
-#else
-#define DEBUGC(...)
-#define DEBUG(...)
-#endif // HSM_DEBUG
-
 HSM_EVENT HSM_RootHandler(HSM *This, HSM_EVENT event, UINT32 param)
 {
-    DEBUG("\tUnhandled event:%d %s[%s]\n", event, This->name, This->curState->name);
+    HSM_DEBUG("\tEvent:%d dropped, No Parent handling of %s[%s]\n", event, This->name, This->curState->name);
     return HSME_NULL;
 }
 
@@ -59,7 +50,7 @@ void HSM_STATE_Create(HSM_STATE *This, char *name, HSM_FN handler, HSM_STATE *pa
     This->level = parent->level + 1;
     if (This->level >= HSM_MAX_DEPTH)
     {
-        DEBUG("Please increase HSM_MAX_DEPTH > %d", This->level);
+        HSM_DEBUG("Please increase HSM_MAX_DEPTH > %d", This->level);
         // assert(0, "Please incrase HSM_MAX_DEPTH");
         while(1);
     }
@@ -71,6 +62,11 @@ void HSM_Create(HSM *This, char *name, HSM_STATE *initState)
     This->curState = initState;
     This->name = name;
     This->hsmDebug = FALSE;
+    // Invoke ENTRY and INIT event
+    HSM_DEBUGC("  %s[%s](ENTRY)\n", This->name, initState->name);
+    This->curState->handler(This, HSME_ENTRY, 0);
+    HSM_DEBUGC("  %s[%s](INIT)\n", This->name, initState->name);
+    This->curState->handler(This, HSME_INIT, 0);
 }
 
 HSM_STATE *HSM_GetState(HSM *This)
@@ -84,30 +80,30 @@ void HSM_Run(HSM *This, HSM_EVENT event, UINT32 param)
     // This runs the state's event handler and forwards unhandled events to
     // the parent state
     HSM_STATE *state = This->curState;
-    DEBUGC("Run %s[%s](evt:%d, param:%08x)\n", This->name, state->name, event, param);
+    HSM_DEBUGC("\nRun %s[%s](evt:%d, param:%08x)\n", This->name, state->name, event, param);
     while (event)
     {
         event = state->handler(This, event, param);
         state = state->parent;
         if (event)
         {
-            DEBUGC("  evt:%d unhandled, passing to %s[%s]\n", event, This->name, state->name);
+            HSM_DEBUGC("  evt:%d unhandled, passing to %s[%s]\n", event, This->name, state->name);
         }
     }
 }
 
 void HSM_Tran(HSM *This, HSM_STATE *nextState, UINT32 param, void (*method)(void))
 {
-#ifdef HSM_CHECK
+#ifdef HSM_CHECK_ENABLE
     // [optional] Check for illegal call to HSM_Tran in HSME_ENTRY or HSME_EXIT
     if (This->hsmTran)
     {
-        DEBUG("!!!!Illegal call of HSM_Tran in HSME_ENTRY or HSME_EXIT Handler!!!!");
+        HSM_DEBUG("!!!!Illegal call of HSM_Tran in HSME_ENTRY or HSME_EXIT Handler!!!!");
         return;
     }
     // Guard HSM_Tran() from certain recursive calls
     This->hsmTran = 1;
-#endif // HSM_CHECK
+#endif // HSM_CHECK_ENABLE
 
     HSM_STATE *list_exit[HSM_MAX_DEPTH];
     HSM_STATE *list_entry[HSM_MAX_DEPTH];
@@ -116,7 +112,7 @@ void HSM_Tran(HSM *This, HSM_STATE *nextState, UINT32 param, void (*method)(void
     UINT8 idx;
     // This performs the state transition with calls of exit, entry and init
     // Bulk of the work handles the exit and entry event during transitions
-    DEBUG("Tran %s[%s -> %s]\n", This->name, This->curState->name, nextState->name);
+    HSM_DEBUG("Tran %s[%s -> %s]\n", This->name, This->curState->name, nextState->name);
     // 1) Find the lowest common parent state
     HSM_STATE *src = This->curState;
     HSM_STATE *dst = nextState;
@@ -148,7 +144,7 @@ void HSM_Tran(HSM *This, HSM_STATE *nextState, UINT32 param, void (*method)(void
     for (idx = 0; idx < cnt_exit; idx++)
     {
         src = list_exit[idx];
-        DEBUGC("  %s[%s](EXIT)\n", This->name, src->name);
+        HSM_DEBUGC("  %s[%s](EXIT)\n", This->name, src->name);
         src->handler(This, HSME_EXIT, param);
     }
     // 3) Call the transitional method hook
@@ -160,17 +156,17 @@ void HSM_Tran(HSM *This, HSM_STATE *nextState, UINT32 param, void (*method)(void
     for (idx = 0; idx < cnt_entry; idx++)
     {
         dst = list_entry[cnt_entry - idx - 1];
-        DEBUGC("  %s[%s](ENTRY)\n", This->name, dst->name);
+        HSM_DEBUGC("  %s[%s](ENTRY)\n", This->name, dst->name);
         dst->handler(This, HSME_ENTRY, param);
     }
     // 5) Now we can set the destination state
     This->curState = nextState;
-#ifdef HSM_CHECK
+#ifdef HSM_CHECK_ENABLE
     This->hsmTran = 0;
-#endif // HSM_CHECK
+#endif // HSM_CHECK_ENABLE
 #ifdef HSM_INIT_FEATURE
     // 6) Invoke INIT signal, NOTE: Only HSME_INIT can recursively call HSM_Tran()
-    DEBUGC("  %s[%s](INIT)\n", This->name, nextState->name);
+    HSM_DEBUGC("  %s[%s](INIT)\n", This->name, nextState->name);
     This->curState->handler(This, HSME_INIT, 0);
 #endif // HSM_INIT_FEATURE
 }

--- a/hsm.c
+++ b/hsm.c
@@ -92,7 +92,7 @@ void HSM_Run(HSM *This, HSM_EVENT event, UINT32 param)
     }
 }
 
-void HSM_Tran(HSM *This, HSM_STATE *nextState, UINT32 param, void (*method)(void))
+void HSM_Tran(HSM *This, HSM_STATE *nextState, UINT32 param, void (*method)(HSM *This, UINT32 param))
 {
 #ifdef HSM_CHECK_ENABLE
     // [optional] Check for illegal call to HSM_Tran in HSME_ENTRY or HSME_EXIT
@@ -150,7 +150,7 @@ void HSM_Tran(HSM *This, HSM_STATE *nextState, UINT32 param, void (*method)(void
     // 3) Call the transitional method hook
     if (method)
     {
-        method();
+        method(This, param);
     }
     // 4) Process all the entry events
     for (idx = 0; idx < cnt_entry; idx++)

--- a/hsm.h
+++ b/hsm.h
@@ -46,9 +46,9 @@ typedef unsigned char UINT8;
 //----State definitions----
 #define HSME_NULL   0
 #define HSME_START  1
-#define HSME_ENTRY  ((HSM_EVENT)(-3))
-#define HSME_EXIT   ((HSM_EVENT)(-2))
-#define HSME_INIT   ((HSM_EVENT)(-1))
+#define HSME_INIT   ((HSM_EVENT)(-3))
+#define HSME_ENTRY  ((HSM_EVENT)(-2))
+#define HSME_EXIT   ((HSM_EVENT)(-1))
 
 //----Debug Macros----
 #ifdef HSM_DEBUG_ENABLE

--- a/hsm.h
+++ b/hsm.h
@@ -45,10 +45,10 @@ typedef unsigned char UINT8;
 
 //----State definitions----
 #define HSME_NULL   0
-#define HSME_ENTRY  1
-#define HSME_EXIT   2
-#define HSME_INIT   3
-#define HSME_START  4
+#define HSME_START  1
+#define HSME_ENTRY  ((HSM_EVENT)(-3))
+#define HSME_EXIT   ((HSM_EVENT)(-2))
+#define HSME_INIT   ((HSM_EVENT)(-1))
 
 //----Debug Macros----
 #ifdef HSM_DEBUG_ENABLE
@@ -114,12 +114,12 @@ HSM_STATE *HSM_GetState(HSM *This);
 // param: Parameter associated with HSM_EVENT
 void HSM_Run(HSM *This, HSM_EVENT event, UINT32 param);
 
-// Func: void HSM_Tran(HSM *This, HSM_STATE *nextState, UINT32 param, void (*method)(void))
+// Func: void HSM_Tran(HSM *This, HSM_STATE *nextState, UINT32 param, void (*method)(HSM *This, UINT32 param));
 // Desc: Transition to another HSM STATE
 // This: Pointer to HSM instance
 // nextState: Pointer to next HSM STATE
-// param: Optional Parameter associated with HSME_ENTRY and HSME_EXIT event
-// moethod: Optional function hook between the HSME_ENTRY and HSME_EXIT event handling
-void HSM_Tran(HSM *This, HSM_STATE *nextState, UINT32 param, void (*method)(void));
+// param: Optional Parameter associated with HSME_ENTRY, HSME_EXIT, HSME_INIT event
+// method: Optional function hook between the HSME_ENTRY and HSME_EXIT event handling
+void HSM_Tran(HSM *This, HSM_STATE *nextState, UINT32 param, void (*method)(HSM *This, UINT32 param));
 
 #endif // __HSM_H__

--- a/hsm.h
+++ b/hsm.h
@@ -33,9 +33,9 @@ typedef unsigned char UINT8;
 
 //----HSM OPTIONAL FEATURES SECTION[BEGIN]----
 // Enable for HSM debugging
-#define HSM_DEBUG
+#define HSM_DEBUG_ENABLE
 // Enable safety checks.  Can be disabled after validating all states
-#define HSM_CHECK
+#define HSM_CHECK_ENABLE
 // Enable HSME_INIT Handling.  Can be disabled if no states handles HSME_INIT
 #define HSM_INIT_FEATURE
 //----HSM OPTIONAL FEATURES SECTION[END]----
@@ -49,6 +49,17 @@ typedef unsigned char UINT8;
 #define HSME_EXIT   2
 #define HSME_INIT   3
 #define HSME_START  4
+
+//----Debug Macros----
+#ifdef HSM_DEBUG_ENABLE
+// Using printf for DEBUG
+#include <stdio.h>
+#define HSM_DEBUGC(...) { if(This->hsmDebug) printf(__VA_ARGS__); }
+#define HSM_DEBUG(...)  { printf(__VA_ARGS__); }
+#else
+#define HSM_DEBUGC(...)
+#define HSM_DEBUG(...)
+#endif // HSM_DEBUG_ENABLE
 
 //----Structure declaration----
 typedef UINT32 HSM_EVENT;
@@ -70,9 +81,9 @@ struct HSM_T
     HSM_STATE *curState;        // Current HSM State
     char *name;                 // Name of HSM Machine
     UINT8 hsmDebug;             // HSM run-time debug flag
-#ifdef HSM_CHECK
+#ifdef HSM_CHECK_ENABLE
     UINT8 hsmTran;              // HSM Transition Flag
-#endif // HSM_CHECK
+#endif // HSM_CHECK_ENABLE
 };
 
 //----Function Declarations----

--- a/makefile
+++ b/makefile
@@ -3,11 +3,11 @@
 # Source files
 TARGET	= camera
 
-# Compler 
+# Compler
 CC    	= gcc
 INC 	= -I .
 OBJ 	= $(addsuffix .o, $(basename $(wildcard *.c)))
-CFLAGS 	= -Werror $(INC)
+CFLAGS 	= -Werror $(INC) -g
 
 # The targets
 .PHONY: all clean


### PR DESCRIPTION
camera.c:
1) Fix initialization order (i.e. create states, then initialize state machine)

hsmc:
1) Change macro name from DEBUG to HSM_DEBUG to prevent name clashes
2) Invoke the HSME_ENTRY and HSME_INIT event on HSM_Create()
3) Pass param to HSME_INIT and method in HSM_Tran() call

hsm.h:
1) Moved HSM_DEBUG macro from hsm.c to hsm.h
2) Changed enum order of HSME_ENTRY, HSME_EXIT, HSME_INIT to end of HSM_EVENT range

makefile:
1) Enable debug symbol in compilation
