### PR TITLE
Removed no-op 'pass' before the print statement.

### DIFF
--- a/hsm.py
+++ b/hsm.py
@@ -78,7 +78,6 @@ class HSM(object):
         the parent state"""
         state = self.curState
         if self.hsmDebug:
-            pass
             print "Run %s[%s](evt:%s)" % (self.name, state.name, event)
         while event:
             event = state.handler(event)


### PR DESCRIPTION
It seemed like the "pass" was left over and not factored out?